### PR TITLE
npmignore *.un~

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.un~
 
 pids
 logs


### PR DESCRIPTION
There's a ton of files with the extension `.un~` in the published module. I don't know why and what that means, but this will make sure that it won't be published the next time.
